### PR TITLE
3.9 Patch: Fix SB Blank Error -> Dev

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -347,7 +347,7 @@ class BaseballReferenceScraper:
             stats_dict.update(icon_threshold_bools)
             
             # FILL BLANKS IF NEEDED
-            keys_to_fill = ['SH','GIDP','IBB','HBP','SF']
+            keys_to_fill = ['SH','GIDP','IBB','HBP','SF','SB','CS',]
             for key in keys_to_fill:
                 if key in stats_dict.keys():
                     raw_value = stats_dict[key]


### PR DESCRIPTION
### Patch Notes

 - Fix error when SB on baseball reference is blank for older cards