### PR TITLE
3.9.2 Patch - Bref Changes and Outliers --> Dev

### DIFF
--- a/mlb_showdown_bot/__main__.py
+++ b/mlb_showdown_bot/__main__.py
@@ -98,13 +98,13 @@ def main():
         statline = player_archive.stats
         data_source = 'Archive'
     else:
-        # try:
-        statline = scraper.player_statline()
-        data_source = scraper.source
-        # except Exception as e:
-        #     if not args.is_wotc:
-        #         print("Error loading statline")
-        #         print(e)
+        try:
+            statline = scraper.player_statline()
+            data_source = scraper.source
+        except Exception as e:
+            if not args.is_wotc:
+                print("Error loading statline")
+                print(e)
 
     # WOTC CARD
     showdown: ShowdownPlayerCard = None

--- a/mlb_showdown_bot/classes/points.py
+++ b/mlb_showdown_bot/classes/points.py
@@ -47,7 +47,10 @@ class PointsMetric(Enum):
     def is_effected_by_decay(self) -> bool:
         return self in [PointsMetric.ONBASE, PointsMetric.AVERAGE, PointsMetric.SLUGGING, PointsMetric.HOME_RUNS]
 
-
+    @property
+    def show_asterisk_in_pts_breakdown(self) -> bool:
+        return self in [PointsMetric.ONBASE, PointsMetric.AVERAGE, PointsMetric.SLUGGING, PointsMetric.HOME_RUNS,]
+    
 class PointsBreakdown(BaseModel):
     
     metric: PointsMetric

--- a/mlb_showdown_bot/scripts/auto_image_suggestions.py
+++ b/mlb_showdown_bot/scripts/auto_image_suggestions.py
@@ -1,7 +1,6 @@
 import argparse
+from datetime import datetime
 import os
-import cloudscraper
-from bs4 import BeautifulSoup
 from pprint import pprint
 import sys
 from pathlib import Path
@@ -15,6 +14,7 @@ parser.add_argument('-cy','--cya', action='store_true', help='Only CYAs', requir
 parser.add_argument('-ys','--year_start', help='Optional year start filter', type=int, required=False, default=None)
 parser.add_argument('-ye','--year_end', help='Optional year end filter', type=int, required=False, default=None)
 parser.add_argument('-l','--limit', help='Optional limit', type=int, required=False, default=None)
+parser.add_argument('-tm', '--team', help='Optional team filter', required=False, default=None)
 parser.add_argument('-yt', '--year_threshold', help='Optional year threshold. Only includes images that are <= the threshold.', required=False, type=int, default=None)
 args = parser.parse_args()
 
@@ -32,7 +32,9 @@ def fetch_image_file_list() -> list[str]:
 def fetch_player_data() -> list[PlayerArchive]:
 
     # LIST OF YEAR INTS FROM 1900 TO NOW
-    year_list = list(range(1900, 2024))
+    # GET CURRENT YEAR
+    current_year = datetime.now().year
+    year_list = list(range(1900, current_year + 1))
     
     # FILTER OUT YEARS BETWEEN YEAR START AND YEAR END ARGS
     if args.year_start is not None:
@@ -55,6 +57,9 @@ def fetch_player_data() -> list[PlayerArchive]:
 image_list = fetch_image_file_list()
 player_data = fetch_player_data()
 
+if len(player_data) == 0:
+    print("NO PLAYERS FOUND")
+
 for player in player_data:
     
     bwar = player.stats.get('bWAR', 0)
@@ -69,17 +74,17 @@ for player in player_data:
     if len(images) > 0:
         continue
 
+    # TEAM CHECK
+    if args.team and args.team != player.team_id: continue
+
     # HOF CHECK
-    if args.hof and not is_hof:
-        continue
+    if args.hof and not is_hof: continue
 
     # MVP CHECK
-    if args.mvp and 'MVP-1' not in awards:
-        continue
+    if args.mvp and 'MVP-1' not in awards: continue
 
     # CYA CHECK
-    if args.cya and 'CYA-1' not in awards:
-        continue
+    if args.cya and 'CYA-1' not in awards: continue
 
     # PRINT PLAYER'S NAME, TEAM, AND YEAR
     print(f"{player.name} {player.team_id} {player.year} {bwar} {hof_str} {mvp_str} {cy_str}")

--- a/mlb_showdown_bot/showdown_player_card.py
+++ b/mlb_showdown_bot/showdown_player_card.py
@@ -3427,10 +3427,16 @@ class ShowdownPlayerCard(BaseModel):
             case Set._2000:
                 name_rotation = 90
                 name_alignment = "center"
+                is_name_over_25_chars = len(name) >= 25
+                is_name_over_22_chars = len(name) >= 22
                 is_name_over_18_chars = len(name) >= 18
                 is_name_over_15_chars = len(name) >= 15
                 name_size = 145
-                if is_name_over_18_chars:
+                if is_name_over_25_chars:
+                    name_size = 80
+                elif is_name_over_22_chars:
+                    name_size = 90
+                elif is_name_over_18_chars:
                     name_size = 110
                 elif is_name_over_15_chars:
                     name_size = 127
@@ -3448,16 +3454,28 @@ class ShowdownPlayerCard(BaseModel):
                 name_rotation = 90
                 name_alignment = "left"
                 name_size = 115 if is_name_over_char_limit else 144
+                if len(name) >= 26:
+                    name_size = 95
+                elif len(name) >= 23:
+                    name_size = 104
                 padding = 15
             case Set._2003:
                 name_rotation = 90
                 name_alignment = "right"
                 name_size = 90 if is_name_over_char_limit else 96
+                if len(name) >= 26:
+                    name_size = 70
+                elif len(name) >= 23:
+                    name_size = 82
                 padding = 60
             case Set._2004 | Set._2005:
                 name_rotation = 0
                 name_alignment = "left"
                 name_size = 80 if is_name_over_char_limit else 96
+                if len(name) >= 26:
+                    name_size = 60
+                elif len(name) >= 23:
+                    name_size = 70
                 padding = 3
                 has_border = True
                 border_color = colors.RED
@@ -3465,6 +3483,8 @@ class ShowdownPlayerCard(BaseModel):
                 name_rotation = 0
                 name_alignment = "left"
                 name_size = 80 if is_name_over_char_limit else 96
+                if len(name) >= 26:
+                    name_size = 70
                 name_font_path = helvetica_neue_cond_black_path
                 padding = 3
                 has_border = False
@@ -3494,7 +3514,7 @@ class ShowdownPlayerCard(BaseModel):
                 last_name = self.__text_image(
                     text = last,
                     size = self.set.template_component_size(TemplateImageComponent.PLAYER_NAME),
-                    font = ImageFont.truetype(name_font_path, size=135),
+                    font = ImageFont.truetype(name_font_path, size=115 if len(last) >= 15 else 135),
                     rotation = name_rotation,
                     alignment = name_alignment,
                     padding = padding,

--- a/mlb_showdown_bot/showdown_player_card.py
+++ b/mlb_showdown_bot/showdown_player_card.py
@@ -1191,6 +1191,9 @@ class ShowdownPlayerCard(BaseModel):
 
                 # MIN OF 4 IP FOR STARTERS
                 ip = max(ip, 4)
+            
+            case _:
+                ip = 1
 
         ip = max(ip, 1)
         
@@ -2358,7 +2361,6 @@ class ShowdownPlayerCard(BaseModel):
         for warning in self.warnings:
             print(f"** {warning}")
 
-
     def player_data_for_html_table(self) -> list[list[str]]:
         """Provides data needed to populate the statline shown on the showdownbot.com webpage.
 
@@ -2471,7 +2473,8 @@ class ShowdownPlayerCard(BaseModel):
         pts_data: list[list[str]] = []    
 
         for breakdown in self.points_breakdown.breakdowns.values():
-            pts_data.append([breakdown.metric_and_category_name, breakdown.value_formatted, str(round(breakdown.points)), breakdown.percentile_formatted])
+            asterisk = '*' if breakdown.metric.show_asterisk_in_pts_breakdown else ''
+            pts_data.append([f'{breakdown.metric_and_category_name}{asterisk}', breakdown.value_formatted, str(round(breakdown.points)), breakdown.percentile_formatted])
 
         if self.points_breakdown.ip_multiplier != 1.0:
             pts_data.append( ['IP MULT', str(self.ip), f"{self.points_breakdown.ip_multiplier}x", en_dash] )

--- a/mlb_showdown_bot/showdown_player_card.py
+++ b/mlb_showdown_bot/showdown_player_card.py
@@ -2341,7 +2341,6 @@ class ShowdownPlayerCard(BaseModel):
         for warning in self.warnings:
             print(f"** {warning}")
 
-        self.player_data_for_html_table()
 
     def player_data_for_html_table(self) -> list[list[str]]:
         """Provides data needed to populate the statline shown on the showdownbot.com webpage.
@@ -2484,13 +2483,13 @@ class ShowdownPlayerCard(BaseModel):
             command_out_str = co_accuracy_tuple[0]
             accuracy_breakdown = self.command_out_accuracy_breakdowns.get(command_out_str, None)
             ops = ''
-            is_boosted = False
+            notes = '—'
             if accuracy_breakdown is not None:
                 ops_list = [bd.comparison for bd in accuracy_breakdown.values() if bd.stat == Stat.OPS]
                 ops = f'{max(ops_list):.3f}'.replace('0.','.') if len(ops_list) > 0 else ''
-                is_boosted = len([bd for bd in accuracy_breakdown.values() if bd.adjustment_pct != 1.0]) > 0
+                notes = max([bd.notes for bd in accuracy_breakdown.values()])
             accuracy = f"{round(100 * co_accuracy_tuple[1], 2)}%" + ('*' if index == 0 else '')
-            accuracy_data.append([f'{index}.  {command_out_str}', accuracy, ops, '*BOOSTED*' if is_boosted else '—'])
+            accuracy_data.append([f'{index}.  {command_out_str}', accuracy, ops, notes])
 
         return accuracy_data
 

--- a/static/front_end/script_3_9_2.js
+++ b/static/front_end/script_3_9_2.js
@@ -309,7 +309,7 @@ function setTheme(themeName) {
 
     var is_dark = themeName == 'dark'
     // ALTER CONTAINERS
-    containers_to_alter = ["container_bg", "overlay", "input_container_column", "input_container", "main_body", "breakdown_output", "radar_container", "trend_container", "player_name", "player_link", "player_shOPS_plus", "estimated_values_footnote", "chart_adjustments_footnote", "opponent_values_footnote", "loader_container_rectangle"]
+    containers_to_alter = ["container_bg", "overlay", "input_container_column", "input_container", "main_body", "breakdown_output", "radar_container", "trend_container", "player_name", "player_link", "player_shOPS_plus", "estimated_values_footnote", "chart_adjustments_footnote", "points_breakdown_footnote", "opponent_values_footnote", "loader_container_rectangle"]
     for (const id of containers_to_alter) {
         var element = document.getElementById(id);
         if (element === null) {

--- a/static/front_end/style.css
+++ b/static/front_end/style.css
@@ -134,11 +134,11 @@
 }
 
 /* ESTIMATED VALUES FOOTNOTE */
-.estimated_values_footnote_light, .rank_values_footnote_light, .opponent_values_footnote_light, .chart_adjustments_footnote_light {
+.estimated_values_footnote_light, .rank_values_footnote_light, .opponent_values_footnote_light, .chart_adjustments_footnote_light, .points_breakdown_footnote_light {
     font-size: 50%;
     color: #000000;
 }
-.estimated_values_footnote_dark, .rank_values_footnote_dark, .opponent_values_footnote_dark, .chart_adjustments_footnote_dark {
+.estimated_values_footnote_dark, .rank_values_footnote_dark, .opponent_values_footnote_dark, .chart_adjustments_footnote_dark, .points_breakdown_footnote_dark {
     font-size:50%; 
     color: #ffffff;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -518,6 +518,7 @@
                                                 </tr>
                                                 {% endfor %}
                                              </table>
+                                             <p class="points_breakdown_footnote_light" id="points_breakdown_footnote"><i>* Slashlines and HR projections used for points are based on Steroid Era opponent. Stats may not match projections against player's era.</i></p>
                                           </div>
          
                                           <div id="chart_div" style="display:none" >


### PR DESCRIPTION
### Patch Notes

- Update to handle first round of bref upgraded tables
  - `CAREER` and `Multi-Year` cards fixed
  - More updates will be needed over the next 6 months as they are slow rolling this out site wide
- Add innings requirement for IP 3 relievers
- Fix `CAREER` cards for players that played in Negro Leagues and MLB
- Fix very long names (ex: Christian Encarnacion-Strand) from being cutoff
- Add footnote to Points detail
- Add more context to `Notes` column on Chart breakdown
- Reduce frequency of high on base super high out hitters for expanded (ex: 12 OB 14+ Outs)