### PR TITLE
3.9.2 Patch: Fix Defensive Combining -> DEV

### DIFF
--- a/mlb_showdown_bot/scripts/auto_image_suggestions.py
+++ b/mlb_showdown_bot/scripts/auto_image_suggestions.py
@@ -71,7 +71,7 @@ for player in player_data:
     hof_str = 'HOF' if is_hof else ''
 
     # SKIP IF PLAYER IS IN IMAGE LIST
-    images = [image for image in image_list if player.bref_id in image and f'({player.team_id})' in image and (abs(int(image.split('-')[1]) - player.year) <= args.year_threshold if args.year_threshold else True)]
+    images = [image for image in image_list if player.bref_id in image and f'({player.team_id})' in image and (abs(int(image.split('-')[1]) - player.year) <= args.year_threshold if args.year_threshold is not None else True)]    
     if len(images) > 0:
         continue
 


### PR DESCRIPTION
### Patch Notes

- Increase threshold to receive IF defense (> 7 games and at least 3% of total games at each position)
- Combine LF/RF and CF into OF when player is also eligible for 1B/2B/3B/SS/CA in 2000-2002 sets
- Fix visual combining of defense with different values