### PR TITLE
(DEV) 3.9.3 Patch: Update Multi-Years w Skipped Seasons

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -128,7 +128,7 @@ class BaseballReferenceScraper:
         max_year = player_ids_pd['year_end'].max()
 
         # CLEAN NAME AND YEAR RANGE FOR CARD
-        name_cleaned = unidecode.unidecode(name.replace("'", "").replace(".", "").lower().strip())
+        name_cleaned = unidecode.unidecode(name.replace("'", "").replace(".", "").lower().strip().split('(')[0].strip())
         try:
             year_ints = [int(y) for y in years]
             year_start = min( min(year_ints), max_year)
@@ -330,6 +330,18 @@ class BaseballReferenceScraper:
                 if 'Did not play' in row.get_text():
                     type = None
                     break
+            
+            # CHECK IF SEASON IS SKIPPED (EX: JOSH GIBSON 1941)
+            players_standard_batting = soup_for_advanced_stats.find('table', attrs={'id': f'players_standard_{table_prefix}'})
+            if players_standard_batting:
+                skipped_year_rows = players_standard_batting.find_all('tr',attrs={'class': 'spacer partial_table'})
+                for row in skipped_year_rows:
+                    header = row.find('th')
+                    if header is None: continue
+                    csk = header.get('csk', '').strip()
+                    if str(year) == csk:
+                        type = None
+                        break
 
             mismatching_type = type != overall_type
             if type is None or mismatching_type:

--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -323,6 +323,14 @@ class BaseballReferenceScraper:
             if type is None and (overall_type or '') == 'Hitter':
                 type = 'Hitter'
 
+            # CHECK IF `DID NOT PLAY` MESSAGE EXISTS FOR THE YEAR
+            table_prefix = 'batting' if (type or '') == 'Hitter' else 'pitching'
+            rows_for_year = soup_for_advanced_stats.find_all('tr',attrs={'id': f'players_standard_{table_prefix}.{year}'})
+            for row in rows_for_year:
+                if 'Did not play' in row.get_text():
+                    type = None
+                    break
+
             mismatching_type = type != overall_type
             if type is None or mismatching_type:
                 continue
@@ -1098,6 +1106,7 @@ class BaseballReferenceScraper:
         if is_full_career:
             standard_row = self.__get_career_totals_row(div_id=re.compile(f'all_{table_prefix}_standard|all_players_standard_{table_prefix}'),soup_object=soup_for_advanced_stats)
         else:
+            standard_row = None
             standard_rows = soup_for_advanced_stats.find_all('tr',attrs={'id': f'players_standard_{table_prefix}.{year}'}) \
                                 or soup_for_advanced_stats.find_all('tr',attrs={'class':'full','id': f'{table_prefix}_standard.{year}'})
             for row in standard_rows:

--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1908,8 +1908,9 @@ class BaseballReferenceScraper:
         year_soup_objects_list = standard_table.find_all('tr', attrs = {'id': re.compile(f'{table_prefix}_standard\.|players_standard_{table_prefix}\.')})
         stat_list = []
         for year_object in year_soup_objects_list:
+            is_total = ' Yr' in year_object.get('id', '')
             stat_object = year_object.find('td',attrs={'data-stat': stat_key})
-            if stat_object:
+            if stat_object and not is_total:
                 stat = stat_object.get_text()
                 stat = self.__convert_to_numeric(stat)
                 stat_list.append(stat)

--- a/test.py
+++ b/test.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
         {'name': 'Bret Boone', 'year': '2001', 'edition': Edition.SUPER_SEASON.value},
         {'name': 'Bob Gibson', 'year': '1968', 'edition': Edition.COOPERSTOWN_COLLECTION.value},
         {'name': 'Jackie Robinson', 'year': 'CAREER', 'edition': Edition.NONE.value},
+        {'name': 'Willie Mays', 'year': 'CAREER', 'edition': Edition.NONE.value},
     ]
     num_tests = len(inputs_to_test)
 


### PR DESCRIPTION
### 3.9.3 Patch: Update Multi-Years w Skipped Seasons

- Fix CAREER cards for players with 1+ seasons of `Did Not Play`
- Fix Multi-Year/CAREER cards for players that skipped season(s)
- Fix CAREER icon thresholds including totals
