### PR TITLE
3.9.3 Fix -> Dev: Career Fielding

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -590,7 +590,7 @@ class BaseballReferenceScraper:
                     
                     if use_stat_per_yr:
                         drs_rating_text = self.__extract_text_for_element(object=position_data, tag='td', attr_key='data-stat', values=['bis_runs_total_per_season', 'f_drs_total_per_year'])
-                        drs_rating = 0 if (drs_rating_text or '') == '' else int(drs_rating_text)
+                        drs_rating = None if (drs_rating_text or '') == '' else int(drs_rating_text)
 
                     # TOTAL ZONE (1953-2003)
                     suffix = '_per_year' if use_stat_per_yr else ''

--- a/mlb_showdown_bot/classes/chart.py
+++ b/mlb_showdown_bot/classes/chart.py
@@ -609,12 +609,17 @@ class Chart(BaseModel):
                 if chart_category.is_out and chart_category != ChartCategory.SO:
                     multiplier = 3/4 if self.is_hitter else 3/4
                     category_limit = self.outs * multiplier if self.outs > 4 else self.outs
+                    if self.is_classic:
+                        category_limit = round(category_limit)
 
                 is_out_max = self.outs if chart_category.is_out else 20 - self.outs
                 category_remaining = is_out_max - sum([v for k,v in self.values.items() if k.is_out == chart_category.is_out])
-                max_values = min(category_limit, category_remaining)
                 final_onbase_category_to_fill = ChartCategory.BB if self.outs_full == 20 else ChartCategory._1B
-                min_values = category_remaining if chart_category in [final_onbase_category_to_fill, ChartCategory.FB] else None
+
+                # DEFINE MIN/MAX VALUES
+                is_final_category_in_section = chart_category in [final_onbase_category_to_fill, ChartCategory.FB]
+                min_values = category_remaining if is_final_category_in_section else None
+                max_values = min(category_remaining, category_remaining if is_final_category_in_section else category_limit)
 
                 # FILL CHART CATEGORY VALUES
                 # FILL METHODS:

--- a/mlb_showdown_bot/showdown_player_card.py
+++ b/mlb_showdown_bot/showdown_player_card.py
@@ -751,11 +751,14 @@ class ShowdownPlayerCard(BaseModel):
                     positions_and_games_played[position] = games_at_position
                     if self.is_hitter:
                         try:
-                            # FOR MULTI YEAR CARDS THAT SPAN CROSS OVER 2016, IGNORE OAA
                             # CHECK WHAT YEARS THE CARD SPANS OVER
                             start_year = min(self.year_list)
                             end_year = max(self.year_list)
-                            use_drs_over_oaa = start_year < 2016 and end_year >= 2016
+
+                            # OAA STARTED IN 2016
+                            # USE DRS OVER OAA FOR YEARS 2014 AND EARLIER
+                            # PLAYERS THAT STARTED IN 2015 USE OAA BECAUSE MOST OF THEIR CAREER IS AFTER 2016
+                            use_drs_over_oaa = start_year <= 2014 and end_year >= 2016
                             
                             # CHECK WHICH DEFENSIVE METRIC TO USE
                             is_drs_available = 'drs' in defensive_stats.keys()

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
         {'name': 'Juan Encarnacion', 'year': '2007', 'edition': Edition.NONE.value},
         {'name': 'Walter Johnson', 'year': '1908', 'edition': Edition.NONE.value},
         {'name': 'Manny Ramirez (LAD)', 'year': '2008', 'edition': Edition.NONE.value},
-        {'name': 'Mike Piazza (FLA)', 'year': '1997', 'edition': Edition.NONE.value},
+        {'name': 'Mike Piazza (FLA)', 'year': '1998', 'edition': Edition.NONE.value},
         {'name': 'Aroldis Chapman (NYY)', 'year': '2016', 'edition': Edition.NONE.value},
         {'name': 'Derek Jeter', 'year': '2006+2014+2008', 'edition': Edition.SUPER_SEASON.value},
         {'name': 'Old Hoss Radbourn', 'year': '1885-1889', 'edition': Edition.NONE.value},


### PR DESCRIPTION
### 3.9.3 Fix -> Dev: Career Fielding

- Fix DRS filling with `0` instead of `null` for CAREER cards
- Adjust scraper to handle blank `pos` column for upgraded fielding tables
- Fix 2000 chart not going up to 20 for extreme small sample size cards
- Adjust cutoff to use OAA for career defense from 2015 -> 2014