### PR TITLE
3.9.5 Patch: Fix empty stat highlight error when creating image

### DIFF
--- a/mlb_showdown_bot/classes/sets.py
+++ b/mlb_showdown_bot/classes/sets.py
@@ -1128,7 +1128,7 @@ class Set(str, Enum):
                 case Set._2004 | Set._2005: return (0, int((self.player_image_crop_size(special_edition)[1] - 2100) / 2))
         if special_edition in [SpecialEdition.ASG_2025]:
             match self:
-                case Set._2000 | Set._2001: return (25,-460) # 2025 ASG HAS LOTS OF SPACE TO THE LEFT SIDE
+                case Set._2000 | Set._2001: return (25,-400) # 2025 ASG HAS LOTS OF SPACE TO THE LEFT SIDE
 
         match self.value:
             case '2000': return (-25,-300)

--- a/mlb_showdown_bot/scripts/all_star_game_set.py
+++ b/mlb_showdown_bot/scripts/all_star_game_set.py
@@ -7,7 +7,7 @@ from time import sleep
 
 sys.path.append('..')
 from baseball_ref_scraper import BaseballReferenceScraper
-from showdown_player_card import ShowdownPlayerCard, StatsPeriod, Set, StatHighlightsType, Edition
+from showdown_player_card import ShowdownPlayerCard, StatsPeriod, Set, StatHighlightsType, Edition, ShowdownImage
 
 parser = argparse.ArgumentParser(description="Create an all star game set for cards.")
 parser.add_argument('-y','--year', type=int, help='Year to use for cards.', required=True)
@@ -64,16 +64,17 @@ for set in sets:
             stats_period = bref_scraper.stats_period or stats_period,
             stats=stats,
             set=set,
-            edition=Edition.ALL_STAR_GAME,
-            card_img_output_folder_path=set_folder_path,
             print_to_cli=False,
             set_name = 'All Star Game',
-            set_number=str(card_number).zfill(3),
-            add_image_border=True,
-            show_year_text=set not in [Set.CLASSIC, Set.EXPANDED, Set._2004, Set._2005],
             is_variable_speed_00_01=False,
-            stat_highlights_type=StatHighlightsType.ALL,
             disable_cache_cleaning=True,
+            image = ShowdownImage(
+                edition=Edition.ALL_STAR_GAME,
+                set_number=str(card_number).zfill(3), is_bordered=True, 
+                stat_highlights_type=StatHighlightsType.ALL,
+                output_folder_path=set_folder_path,
+                output_file_name=f"{str(card_number).zfill(3)}_{player_name}.png",
+            ),
         )
 
         if bref_scraper.source != 'Local Cache':

--- a/mlb_showdown_bot/scripts/all_star_game_set.py
+++ b/mlb_showdown_bot/scripts/all_star_game_set.py
@@ -35,7 +35,9 @@ for set in sets:
     for index, row in roster_pd.iterrows():
         
         # CARD INFO
+        
         player_name: str = row['Name']
+        bref_id:str = row['Bref Id']
         year_str = str(args.year)
         card_number = index+1
         print(f"  {str(card_number).zfill(3)}/{len(roster_pd)}: {player_name[:12].ljust(20)}", end='\r')
@@ -48,7 +50,7 @@ for set in sets:
             end_date=f"{args.year}-07-16", # CHANGE THIS PER YEAR
         )
         bref_scraper = BaseballReferenceScraper(
-            name=player_name, 
+            name=bref_id, 
             year=year_str, 
             stats_period=stats_period, 
             disable_cleaning_cache=True, 

--- a/mlb_showdown_bot/showdown_player_card.py
+++ b/mlb_showdown_bot/showdown_player_card.py
@@ -2040,7 +2040,7 @@ class ShowdownPlayerCard(BaseModel):
 
                 # CHECK FOR VALUE
                 stat = stats.get(key, None)
-                if stat is None:
+                if stat is None or len(str(stat)) == 0:
                     continue
                 stat_formatted = self.__stat_formatted(key, stat)
 
@@ -2086,7 +2086,8 @@ class ShowdownPlayerCard(BaseModel):
         Returns:
           Formatted stat string.
         """
-
+        if len(str(value)) == 0 or value is None:
+            return '0'
         match category:
             case 'batting_avg' | 'onbase_perc' | 'slugging_perc' | 'onbase_plus_slugging':
                 return f"{value:.3f}".replace('0.', '.')
@@ -2096,7 +2097,7 @@ class ShowdownPlayerCard(BaseModel):
                 return f"{value:.0f}"
             case 'dWAR' | 'bWAR' | 'strikeouts_per_nine':
                 return f"{float(value):.1f}"
-            case _: return str(round(value))
+            case _: return str(round(value)) if value is not None else 0
 
 # ------------------------------------------------------------------------
 # PLAYER VALUE METHODS

--- a/mlb_showdown_bot/showdown_player_card.py
+++ b/mlb_showdown_bot/showdown_player_card.py
@@ -5113,9 +5113,9 @@ class ShowdownPlayerCard(BaseModel):
             has_stars = img_component in [PlayerImageComponent.GLOW, PlayerImageComponent.SILHOUETTE] and self.image.special_edition == SpecialEdition.ASG_2025
             if has_stars:
                 stars_image = Image.open(self.__card_art_path(PlayerImageComponent.STARS.name))
-                centered_paste_coordinates = (750-int(stars_image.size[0]/2),220)
+                centered_paste_coordinates = (750-int(stars_image.size[0]/2),175)
                 player_image_adjustment = self.set.player_image_crop_adjustment(special_edition=self.image.special_edition)
-                star_paste_coordinates = self.__coordinates_adjusted_for_bordering(coordinates=(centered_paste_coordinates[0] - player_image_adjustment[0], centered_paste_coordinates[1] - player_image_adjustment[1]),is_disabled=not img_component.adjust_paste_coordinates_for_bordered)
+                star_paste_coordinates = (centered_paste_coordinates[0] - player_image_adjustment[0], centered_paste_coordinates[1] - player_image_adjustment[1])
                 player_img_components.append((stars_image, star_paste_coordinates))
 
             # PASTE IMAGE
@@ -6230,7 +6230,8 @@ class ShowdownPlayerCard(BaseModel):
           None
         """
 
-        self.image.output_file_name = f'{self.name}-{str(datetime.now())}.png'
+        if self.image.output_file_name is None:
+            self.image.output_file_name = f'{self.name}-{str(datetime.now())}.png'
         if self.image.set_name:
             self.image.output_file_name = f'{self.image.set_number} {self.name}{img_name_suffix}.png'            
         


### PR DESCRIPTION
### 3.9.5 Patch: Fix empty stat highlight error when creating image

- Fix issue where the card image would fail to run if the player has a stat that is empty (ex: Jose Trevino has `''` SB)