### PR TITLE
(DEV) 3.9.5 Patch: Handle new skipped year divider

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1832,6 +1832,8 @@ class BaseballReferenceScraper:
                 continue
             if 'YR' in year_str.upper():
                 continue
+            if year_str.strip() == '':
+                continue
             year = int(year_str)
             if len(years_filter_list) < 1 or (year in years_filter_list):
                 team = self.__extract_text_for_element(object=year_object, tag='td', attr_key='data-stat', values=['team_ID', 'team_name_abbr'])


### PR DESCRIPTION
### (DEV) 3.9.5 Patch: Handle new skipped year divider

Bref changed the way skipped years appear on tables. In the past they showed as "did not play" but now are just a blank divider.

<img width="1135" height="624" alt="Skips" src="https://github.com/user-attachments/assets/eca431a2-abdc-41bd-8498-f5d27ae9dd5f" />
