### PR TITLE
3.9.5 Patch: Update 20 icon for career cards with upgraded tables

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1832,6 +1832,8 @@ class BaseballReferenceScraper:
                 continue
             if 'YR' in year_str.upper():
                 continue
+            if year_str.strip() == '':
+                continue
             year = int(year_str)
             if len(years_filter_list) < 1 or (year in years_filter_list):
                 team = self.__extract_text_for_element(object=year_object, tag='td', attr_key='data-stat', values=['team_ID', 'team_name_abbr'])

--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1864,7 +1864,8 @@ class BaseballReferenceScraper:
         """
         table_prefix = 'batting' if type == 'Hitter' else 'pitching'
         standard_table = homepage_soup.find('div', attrs = {'id': re.compile(f'all_{table_prefix}_standard|all_players_standard_{table_prefix}')})
-        year_soup_objects_list = standard_table.find_all('tr', attrs = {'id': re.compile(f'{table_prefix}_standard\.|players_standard_{table_prefix}\.')})
+        standard_table_body = standard_table.find('tbody') if standard_table else None
+        year_soup_objects_list = standard_table_body.find_all('tr', attrs = {'id': re.compile(f'{table_prefix}_standard\.|players_standard_{table_prefix}\.')}) if standard_table_body else []
         stat_list = []
         for year_object in year_soup_objects_list:
             is_total = ' Yr' in year_object.get('id', '')


### PR DESCRIPTION
### 3.9.5 Patch: Update 20 icon for career cards with upgraded tables

- Fix career cards showing 20 icon for relievers if they have 20 career wins. Caused by upgraded tables showing totals differently