### PR TITLE
(DEV) 3.9.5 Patch: Fix dWAR being blank in skipped seasons

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1780,7 +1780,8 @@ class BaseballReferenceScraper:
         for stats in yearly_stats_dict.values():
 
             # DWAR
-            dWar_list.append(float(stats['dWAR']))
+            dWAR_raw = stats.get('dWAR', 0)
+            dWar_list.append(float(dWAR_raw) if dWAR_raw is not None and dWAR_raw != '' else 0.0)
 
             # POSITIONS AND DEFENSE
             positions_dict = stats.get('positions', {})

--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1781,7 +1781,7 @@ class BaseballReferenceScraper:
 
             # DWAR
             dWAR_raw = stats.get('dWAR', 0)
-            dWar_list.append(float(dWAR_raw) if dWAR_raw is not None and dWAR_raw != '' else 0.0)
+            dWar_list.append(float(dWAR_raw) if dWAR_raw is not None and str(dWAR_raw) != '' else 0.0)
 
             # POSITIONS AND DEFENSE
             positions_dict = stats.get('positions', {})


### PR DESCRIPTION
### (DEV) 3.9.5 Patch: Fix dWAR being blank in skipped seasons

This pull request improves the robustness of the `__combine_multi_year_positions` method in `baseball_ref_scraper.py` by handling missing or empty `dWAR` values more gracefully. Previously, the code assumed that `dWAR` was always present and non-empty, which could cause errors if the data was incomplete.

**Data handling improvements:**

* Updated the logic in `__combine_multi_year_positions` to safely handle missing or empty `dWAR` values by defaulting to `0.0` when necessary.