### PR TITLE
3.9.5 Patch: Fix dWAR being blank in skipped seasons

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1780,7 +1780,8 @@ class BaseballReferenceScraper:
         for stats in yearly_stats_dict.values():
 
             # DWAR
-            dWar_list.append(float(stats['dWAR']))
+            dWAR_raw = stats.get('dWAR', 0)
+            dWar_list.append(float(dWAR_raw) if dWAR_raw is not None and str(dWAR_raw) != '' else 0.0)
 
             # POSITIONS AND DEFENSE
             positions_dict = stats.get('positions', {})

--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1864,7 +1864,8 @@ class BaseballReferenceScraper:
         """
         table_prefix = 'batting' if type == 'Hitter' else 'pitching'
         standard_table = homepage_soup.find('div', attrs = {'id': re.compile(f'all_{table_prefix}_standard|all_players_standard_{table_prefix}')})
-        year_soup_objects_list = standard_table.find_all('tr', attrs = {'id': re.compile(f'{table_prefix}_standard\.|players_standard_{table_prefix}\.')})
+        standard_table_body = standard_table.find('tbody') if standard_table else None
+        year_soup_objects_list = standard_table_body.find_all('tr', attrs = {'id': re.compile(f'{table_prefix}_standard\.|players_standard_{table_prefix}\.')}) if standard_table_body else []
         stat_list = []
         for year_object in year_soup_objects_list:
             is_total = ' Yr' in year_object.get('id', '')

--- a/mlb_showdown_bot/postgres_db.py
+++ b/mlb_showdown_bot/postgres_db.py
@@ -87,7 +87,7 @@ class PostgresDB:
 # QUERIES
 # ------------------------------------------------------------------------
 
-    def execute_query(self, query:sql.SQL, filter_values:tuple) -> list[dict]:
+    def execute_query(self, query:sql.SQL, filter_values:tuple=None) -> list[dict]:
         """Execute a query and transform data to list of dictionaries.
         Keys represent field names, values are the rows from the database.
         
@@ -378,8 +378,20 @@ class PostgresDB:
         if len(result_list) == 0: return None
 
         return PlayerArchive(**result_list[0])
-    
 
+    def fetch_current_season_player_data(self) -> list[dict]:
+        """Fetch current season player data from the database."""
+
+        if not self.connection:
+            return None
+
+        query = sql.SQL("""
+            SELECT *
+            FROM current_season_players
+        """)
+
+        result_list = self.execute_query(query=query)
+        return result_list
 
 # ------------------------------------------------------------------------
 # TABLES


### PR DESCRIPTION
### 3.9.5 Patch: Fix dWAR being blank in skipped seasons

This pull request improves the robustness of the `__combine_multi_year_positions` method in `baseball_ref_scraper.py` by handling missing or empty `dWAR` values more gracefully. Previously, the code assumed that `dWAR` was always present and non-empty, which could cause errors if the data was incomplete.

**Data handling improvements:**

* Updated the logic in `__combine_multi_year_positions` to safely handle missing or empty `dWAR` values by defaulting to `0.0` when necessary.