### PR TITLE
3.9.5 Patch: Update IP/GS for multi-year

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1780,7 +1780,8 @@ class BaseballReferenceScraper:
         for stats in yearly_stats_dict.values():
 
             # DWAR
-            dWar_list.append(float(stats['dWAR']))
+            dWAR_raw = stats.get('dWAR', 0)
+            dWar_list.append(float(dWAR_raw) if dWAR_raw is not None and str(dWAR_raw) != '' else 0.0)
 
             # POSITIONS AND DEFENSE
             positions_dict = stats.get('positions', {})

--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1721,6 +1721,7 @@ class BaseballReferenceScraper:
             'award_summary': ','.join,
             'bWAR': 'sum',
             'onbase_plus_slugging_plus': wa_games,
+            'IP/GS': 'mean',
         }
         columns_to_remove = list(set(column_aggs.keys()) - set(yearPd.columns))
         if max(years) < 2015:


### PR DESCRIPTION
### 3.9.5 Patch: Update IP/GS for multi-year

This pull request makes a targeted update to the aggregation logic in the `__combine_multi_year_dict` method of `baseball_ref_scraper.py`. The main change is the addition of a new aggregation rule for the `'IP/GS'` column, specifying that its mean should be calculated when combining multi-year statistics.

**Aggregation logic update:**

* Added a mean aggregation for the `'IP/GS'` column in the `column_aggs` dictionary within the `__combine_multi_year_dict` method of `baseball_ref_scraper.py`.