### PR TITLE
3.9.5 Patch: Fix end date issue for Realtime stats

### DIFF
--- a/mlb_showdown_bot/baseball_ref_scraper.py
+++ b/mlb_showdown_bot/baseball_ref_scraper.py
@@ -1721,6 +1721,7 @@ class BaseballReferenceScraper:
             'award_summary': ','.join,
             'bWAR': 'sum',
             'onbase_plus_slugging_plus': wa_games,
+            'IP/GS': 'mean',
         }
         columns_to_remove = list(set(column_aggs.keys()) - set(yearPd.columns))
         if max(years) < 2015:

--- a/mlb_showdown_bot/mlb_stats_api.py
+++ b/mlb_showdown_bot/mlb_stats_api.py
@@ -393,7 +393,7 @@ def get_player_realtime_game_stats_and_game_boxscore(year:str, bref_stats:dict, 
             bref_stats is None or \
             not is_current_year or \
             not stats_period.type.check_for_realtime_stats or \
-            stats_period.end_date < datetime.now().date():
+            (stats_period.end_date < datetime.now().date() if stats_period.end_date is not None else False):
         return None, None, None
     
     player_name = bref_stats.get('name', '')


### PR DESCRIPTION
### 3.9.5 Patch: Fix end date issue for Realtime stats

This pull request makes a minor update to the logic for checking the `end_date` of a `stats_period` in the `get_player_realtime_game_stats_and_game_boxscore` function. The change ensures that the comparison to the current date only occurs if `end_date` is not `None`, preventing potential errors.

* Added a conditional check to ensure `stats_period.end_date` is not `None` before comparing it to the current date in `mlb_showdown_bot/mlb_stats_api.py` (`get_player_realtime_game_stats_and_game_boxscore`).