### PR TITLE
Fix awards loop when empty

### DIFF
--- a/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
+++ b/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
@@ -908,7 +908,7 @@ class PlayerStatsNormalizer:
 
         # ----- AWARDS ----- #
 
-        for award in mlb_player.awards:
+        for award in (mlb_player.awards or []):
 
             # ONLY INCLUDE RELEVANT AWARDS
             if not award.is_included_in_accolades:


### PR DESCRIPTION
### Fix awards loop when empty

This pull request makes a small change to the way awards are processed in the `_convert_mlb_stats_awards_and_ranks_to_accolades_dict` function. It ensures that the code safely handles cases where `mlb_player.awards` might be `None` by iterating over an empty list instead, preventing potential errors.

* Changed the awards iteration to use `(mlb_player.awards or [])` for safe handling when `mlb_player.awards` is `None` in `_convert_mlb_stats_awards_and_ranks_to_accolades_dict` (`mlb_showdown_bot/core/card/stats/normalized_player_stats.py`).