### PR TITLE
(DEV) Optimize workers and cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ mlb_showdown_bot/data/MLB Showdown WOTC Cards*
 mlb_showdown_bot/core/set_builder/output/
 mlb_showdown_bot/core/set_builder/expansions/
 static/output/
+static/card_of_the_day/
 mlb_showdown_bot/uploads/
 mlb_showdown_bot/output/
 mlb_showdown_bot/cache_data/

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --workers 3 app:app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --workers 3 app:app
+web: gunicorn --workers 3 app:app

--- a/app.py
+++ b/app.py
@@ -42,6 +42,11 @@ from mlb_showdown_bot.core.database.postgres_db import _get_pool
 _get_pool('DATABASE_URL_LOGS')
 _get_pool('DATABASE_URL_ARCHIVE')
 
+@app.route('/static/card_of_the_day/<path:filename>')
+def serve_card_of_the_day_files(filename):
+    """Serve card of the day images (persisted, not cleaned up)"""
+    return send_from_directory(os.path.join('static', 'card_of_the_day'), filename)
+
 @app.route('/static/output/<path:filename>')
 def serve_output_files(filename):
     """Serve generated card images"""

--- a/mlb_showdown_bot/api/card_db.py
+++ b/mlb_showdown_bot/api/card_db.py
@@ -1,10 +1,21 @@
 from pprint import pprint
+import os
+import time
 from flask import Blueprint, request, jsonify
 
 from mlb_showdown_bot.core.card.showdown_player_card import ShowdownPlayerCard, Team
 from ..core.database.postgres_db import PostgresDB
 
 card_db_bp = Blueprint('card_data', __name__)
+
+_HOMEPAGE_CACHE_TTL = 8 * 60 * 60  # 8 hours
+
+_card_of_the_day_cache: dict[str, tuple[dict, float]] = {}
+_CARD_OF_THE_DAY_FOLDER = "static/card_of_the_day"
+
+_trending_cache: dict[str, tuple[list, float]] = {}
+_popular_cache: dict[str, tuple[list, float]] = {}
+_spotlight_cache: dict[str, tuple[list, float]] = {}  # key: "{set}:{limit}"
 
 @card_db_bp.route('/cards/search', methods=["POST", "GET"])
 def fetch_card_list():
@@ -74,13 +85,18 @@ def fetch_total_card_count():
 def fetch_trending_cards():
     """Fetch trending cards from the database"""
     try:
-
         payload = request.get_json() or {}
-        showdown_set = payload.get('set')
+        showdown_set = payload.get('set') or 'default'
+
+        cached_result, cached_at = _trending_cache.get(showdown_set, (None, 0.0))
+        if cached_result is not None and (time.time() - cached_at) < _HOMEPAGE_CACHE_TTL:
+            return jsonify({'trending_cards': cached_result})
+
         db = PostgresDB()
         trending_cards = db.fetch_trending_cards(set=showdown_set)
         db.close_connection()
 
+        _trending_cache[showdown_set] = (trending_cards, time.time())
         return jsonify({'trending_cards': trending_cards})
 
     except Exception as e:
@@ -91,13 +107,18 @@ def fetch_trending_cards():
 def fetch_popular_cards():
     """Fetch all-time popular cards from the database"""
     try:
-
         payload = request.get_json() or {}
-        showdown_set = payload.get('set')
+        showdown_set = payload.get('set') or 'default'
+
+        cached_result, cached_at = _popular_cache.get(showdown_set, (None, 0.0))
+        if cached_result is not None and (time.time() - cached_at) < _HOMEPAGE_CACHE_TTL:
+            return jsonify({'popular_cards': cached_result})
+
         db = PostgresDB()
         popular_cards = db.fetch_popular_cards(set=showdown_set)
         db.close_connection()
 
+        _popular_cache[showdown_set] = (popular_cards, time.time())
         return jsonify({'popular_cards': popular_cards})
 
     except Exception as e:
@@ -108,14 +129,20 @@ def fetch_popular_cards():
 def fetch_spotlight_cards():
     """Fetch spotlight cards from the database"""
     try:
-
         payload = request.get_json() or {}
-        showdown_set = payload.get('set')
+        showdown_set = payload.get('set') or 'default'
         limit = payload.get('limit', 4)
+        cache_key = f"{showdown_set}:{limit}"
+
+        cached_result, cached_at = _spotlight_cache.get(cache_key, (None, 0.0))
+        if cached_result is not None and (time.time() - cached_at) < _HOMEPAGE_CACHE_TTL:
+            return jsonify({'spotlight_cards': cached_result})
+
         db = PostgresDB()
         spotlight_cards = db.fetch_latest_spotlight_cards(set=showdown_set, limit=limit)
         db.close_connection()
 
+        _spotlight_cache[cache_key] = (spotlight_cards, time.time())
         return jsonify({'spotlight_cards': spotlight_cards})
 
     except Exception as e:
@@ -127,19 +154,25 @@ def fetch_card_of_the_day():
     """Fetch the card of the day from the database"""
     try:
         payload = request.get_json() or {}
-        showdown_set = payload.get('set')
+        showdown_set = payload.get('set') or 'default'
+
+        cached_result, cached_at = _card_of_the_day_cache.get(showdown_set, (None, 0.0))
+        if cached_result is not None and (time.time() - cached_at) < _HOMEPAGE_CACHE_TTL:
+            return jsonify({'card_of_the_day': cached_result})
+
         db = PostgresDB()
         card_of_the_day = db.fetch_card_of_the_day(set=showdown_set)
         db.close_connection()
 
         # GENERATE AN IMAGE FOR THE CARD
+        os.makedirs(_CARD_OF_THE_DAY_FOLDER, exist_ok=True)
         card_json = card_of_the_day.get('card_data')
         card = ShowdownPlayerCard(**card_json)
-        card.image.output_folder_path = "static/output"
-
-        # PRODUCE IMAGE AND UPDATE DATASET
+        card.image.output_folder_path = _CARD_OF_THE_DAY_FOLDER
         card.generate_card_image()
         card_of_the_day['card_data'] = card.as_json()
+
+        _card_of_the_day_cache[showdown_set] = (card_of_the_day, time.time())
 
         return jsonify({'card_of_the_day': card_of_the_day})
 


### PR DESCRIPTION
### (DEV) Optimize workers and cache

This pull request introduces caching for several homepage API endpoints to improve performance and reduce database load, and adds a new static file route for serving "card of the day" images. The most significant changes are grouped below.

**API caching for homepage endpoints:**

* Added in-memory caching (8-hour TTL) for trending, popular, spotlight, and card of the day endpoints in `card_db.py`, reducing redundant database queries and improving response times. [[1]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7R2-R19) [[2]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7L77-R99) [[3]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7L94-R121) [[4]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7L111-R145) [[5]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7L130-R176)
* Updated cache keys to support different sets and limits for more granular caching. [[1]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7L111-R145) [[2]](diffhunk://#diff-94e1f56d9e0e22127d690637315d1a2a8ab9cf01f341914e51c37cb152b448c7L130-R176)

**Static file serving:**

* Added a new Flask route in `app.py` to serve persisted "card of the day" images from the `static/card_of_the_day` directory.
* Ensured generated "card of the day" images are stored in the correct folder and created the directory if it doesn't exist.

**Server process improvement:**

* Increased the number of Gunicorn workers from 1 to 3 in the `Procfile` to better handle concurrent web requests.