### PR TITLE
(DEV) Patch/4.11 - Feedback Round II

### DIFF
--- a/frontend/src/components/games/GameDetail.tsx
+++ b/frontend/src/components/games/GameDetail.tsx
@@ -42,10 +42,11 @@ type GameDetailProps = {
     showdownSet?: string;
     /** When false, stops auto-refresh polling (e.g. user switched to another tab) */
     isActive?: boolean;
+    className?: string;
     onBack: () => void;
 };
 
-export default function GameDetail({ gamePk, sportId, season, showdownSet, isActive = true, onBack }: GameDetailProps) {
+export default function GameDetail({ gamePk, sportId, season, showdownSet, isActive = true, className, onBack }: GameDetailProps) {
     const [boxscore, setBoxscore] = useState<GameBoxscoreDetail | null>(null);
     const [cardMap, setCardMap] = useState<CardMap>({});
     const [isLoading, setIsLoading] = useState(true);
@@ -245,7 +246,7 @@ export default function GameDetail({ gamePk, sportId, season, showdownSet, isAct
     const detailedState = boxscore.status?.detailed_state ?? (isFinal ? "Final" : "In Progress");
 
     return (
-        <div className="space-y-4 pb-24">
+        <div className={`space-y-4 pb-24 ${className}`}>
             <BackButton onBack={onBack} />
 
             {/* Header: Teams + Score */}

--- a/frontend/src/components/games/GameDetail.tsx
+++ b/frontend/src/components/games/GameDetail.tsx
@@ -46,6 +46,31 @@ type GameDetailProps = {
     onBack: () => void;
 };
 
+const cardDefenseForPosition = (card: ShowdownBotCard | undefined, position: string | null) => {
+    if (!card) return null;
+    if (!position) return null;
+    if (position === "DH") return null; // DH has no defensive value
+    
+    // Check for exact position match first
+    const exactMatch = card.positions_and_defense[position];
+    if (exactMatch != null) return exactMatch;
+
+    // If no exact match, check for these common position groupings
+    const positionGroups: Record<string, string[]> = {
+        'IF': ['1B', '2B', '3B', 'SS'],
+        'OF': ['LF', 'CF', 'RF'],
+        'LF/RF': ['LF', 'RF'],
+    };
+    for (const group in positionGroups) {
+        if (positionGroups[group].includes(position)) {
+            const groupMatch = card.positions_and_defense[group];
+            if (groupMatch != null) return groupMatch;
+        }
+    }
+
+    return null;
+}
+
 export default function GameDetail({ gamePk, sportId, season, showdownSet, isActive = true, className, onBack }: GameDetailProps) {
     const [boxscore, setBoxscore] = useState<GameBoxscoreDetail | null>(null);
     const [cardMap, setCardMap] = useState<CardMap>({});
@@ -761,31 +786,6 @@ function ProbableStartingPitchers({
 }
 
 function PlayerNameCell({ name, position, card, ptsChange, isLoadingCard }: { name: string; position?: string; card?: ShowdownBotCard; ptsChange?: number | null; isLoadingCard?: boolean; onClick?: () => void }) {
-
-    const defenseForPosition = () => {
-        if (!card) return null;
-        if (!position) return null;
-        if (position === "DH") return null; // DH has no defensive value
-        
-        // Check for exact position match first
-        const exactMatch = card.positions_and_defense[position];
-        if (exactMatch != null) return exactMatch;
-
-        // If no exact match, check for these common position groupings
-        const positionGroups: Record<string, string[]> = {
-            'IF': ['1B', '2B', '3B', 'SS'],
-            'OF': ['LF', 'CF', 'RF'],
-            'LF/RF': ['LF', 'RF'],
-        };
-        for (const group in positionGroups) {
-            if (positionGroups[group].includes(position)) {
-                const groupMatch = card.positions_and_defense[group];
-                if (groupMatch != null) return groupMatch;
-            }
-        }
-
-        return null;
-    }
         
     return (
         <div className="flex items-center space-x-1.5">
@@ -813,7 +813,7 @@ function PlayerNameCell({ name, position, card, ptsChange, isLoadingCard }: { na
                         </span>
                     )}
                     {position && <div className="text-[10px] text-(--text-tertiary)">
-                        {position}{defenseForPosition() != null && (defenseForPosition() || 0) >= 0 ? "+" : ""}{defenseForPosition()}
+                        {position}{cardDefenseForPosition(card, position) != null && (cardDefenseForPosition(card, position) || 0) >= 0 ? "+" : ""}{cardDefenseForPosition(card, position)}
                     </div>}
                 </div>
                 
@@ -851,12 +851,31 @@ function BattingTable({ team, sportId, cardMap, onCardSelect, isLoadingCards, ha
             return orderA - orderB;
         });
 
+    // PTS
     const totalPoints = hasCards
         ? sortedBatters.reduce((sum, b) => sum + (cardMap[cardKey(b.id, 'batting')]?.card?.points ?? 0), 0)
         : 0;
     const totalPointsChange = hasCards && hasGameStarted
         ? sortedBatters.reduce((sum, b) => sum + (cardMap[cardKey(b.id, 'batting')]?.in_season_trends?.pts_change.day ?? 0), 0)
         : 0;
+    
+    // CURRENT DEFENSE
+    const INFIELD = new Set(['1B', '2B', '3B', 'SS']);
+    const OUTFIELD = new Set(['LF', 'CF', 'RF']);
+    const defTotals = hasCards
+        ? sortedBatters.filter((b) => b.is_in_lineup).reduce(
+            (acc, b) => {
+                const card = cardMap[cardKey(b.id, 'batting')]?.card ?? undefined;
+                const val = cardDefenseForPosition(card, b.position ?? null);
+                if (val == null) return acc;
+                if (b.position === 'C')                  acc.catcher += val;
+                else if (INFIELD.has(b.position ?? ''))  acc.infield += val;
+                else if (OUTFIELD.has(b.position ?? '')) acc.outfield += val;
+                return acc;
+            },
+            { infield: 0, outfield: 0, catcher: 0 }
+        )
+        : null;
 
     return (
         <div className="rounded-xl border border-(--divider) bg-(--background-secondary) overflow-hidden">
@@ -869,6 +888,13 @@ function BattingTable({ team, sportId, cardMap, onCardSelect, isLoadingCards, ha
                     style={{ backgroundColor: badgeBg, color: badgeText }}
                 >{team.team.abbreviation}</span>
                 <span className="text-xs text-(--secondary) font-semibold">Batting</span>
+                {defTotals && (
+                    <div className="ml-auto flex items-center gap-x-3">
+                        <span className="text-[10px] text-(--secondary)">C {defTotals.catcher >= 0 ? '+' : ''}{defTotals.catcher}</span>
+                        <span className="text-[10px] text-(--secondary)">IF {defTotals.infield >= 0 ? '+' : ''}{defTotals.infield}</span>
+                        <span className="text-[10px] text-(--secondary)">OF {defTotals.outfield >= 0 ? '+' : ''}{defTotals.outfield}</span>
+                    </div>
+                )}
                 {hasCards && totalPoints > 0 && (
                     <TablePointsSummary totalPoints={totalPoints} pointsChange={totalPointsChange} backgroundColor={badgeBgSecondary} />
                 )}

--- a/frontend/src/components/seasons/SeasonLeaders.tsx
+++ b/frontend/src/components/seasons/SeasonLeaders.tsx
@@ -98,8 +98,8 @@ export default function SeasonLeaders({ seasonId, season, showdownSet, sportId, 
         const pitchingCategoryIds = PITCHING_CATEGORIES.map(c => c.id);
 
         Promise.all([
-            fetchSeasonLeaders(seasonId, hittingCategoryIds, ['hitting'], 3),
-            fetchSeasonLeaders(seasonId, pitchingCategoryIds, ['pitching'], 3),
+            fetchSeasonLeaders(seasonId, hittingCategoryIds, ['hitting'], 5),
+            fetchSeasonLeaders(seasonId, pitchingCategoryIds, ['pitching'], 5),
         ])
             .then(([hittingRes, pitchingRes]) => {
                 const combined = [...hittingRes.leaders, ...pitchingRes.leaders];
@@ -230,7 +230,7 @@ export default function SeasonLeaders({ seasonId, season, showdownSet, sportId, 
     return (
         <div className="pb-24">
             {/* Header */}
-            <div className="flex items-center justify-between gap-4 mb-5 flex-wrap">
+            <div className="flex items-center justify-between gap-4 mb-5 flex-wrap lg:pr-6">
                 <div className="flex items-center gap-2">
                     <FaTrophy className={`text-sm ${isDark ? 'text-yellow-400' : 'text-yellow-500'}`} />
                     <span className={`text-sm font-bold uppercase tracking-wide ${isDark ? 'text-neutral-400' : 'text-neutral-500'}`}>
@@ -265,10 +265,10 @@ export default function SeasonLeaders({ seasonId, season, showdownSet, sportId, 
             {/* Loading state (first load, no data yet) */}
             {isLoadingLeaders && leaderGroups.length === 0 && (
                 <div className="space-y-8">
-                    {visibleCategories.slice(0, 4).map((cat) => (
+                    {visibleCategories.slice(0, 6).map((cat) => (
                         <div key={cat.id}>
                             <div className={`h-4 w-32 rounded mb-3 animate-pulse ${isDark ? 'bg-neutral-700' : 'bg-neutral-200'}`} />
-                            <div className="flex gap-3 overflow-x-auto scrollbar-hide lg:grid lg:grid-cols-3">
+                            <div className="flex gap-3 overflow-x-auto scrollbar-hide -mx-6 px-6 lg:mx-0 lg:px-0 lg:grid lg:grid-cols-3">
                                 {[0, 1, 2].map(i => (
                                     <div
                                         key={i}
@@ -288,7 +288,7 @@ export default function SeasonLeaders({ seasonId, season, showdownSet, sportId, 
                         const group = groupsByCategory[catDef.apiKey];
                         // Show placeholder entries while loading or if no data for this category
                         const entries: (PlayerLeader | null)[] = group
-                            ? (group.leaders ?? []).slice(0, 3)
+                            ? (group.leaders ?? []).slice(0, 6)
                             : [null, null, null];
 
                         // Pad to 3 if fewer entries
@@ -297,7 +297,7 @@ export default function SeasonLeaders({ seasonId, season, showdownSet, sportId, 
                         return (
                             <div key={catDef.id}>
                                 {/* Category header */}
-                                <div className="flex items-center gap-2 mb-3">
+                                <div className="flex items-center gap-2 mb-3 lg:pr-6">
                                     <span className={`text-xs font-bold uppercase tracking-wide ${isDark ? 'text-neutral-400' : 'text-neutral-500'}`}>
                                         {catDef.label}
                                     </span>
@@ -307,7 +307,7 @@ export default function SeasonLeaders({ seasonId, season, showdownSet, sportId, 
                                 </div>
 
                                 {/* 3 cards */}
-                                <div className="flex gap-3 overflow-x-scroll scrollbar-hide">
+                                <div className="flex gap-3 overflow-x-scroll scrollbar-hide -mx-6 px-6 lg:mx-0 lg:px-0">
                                     {entries.map((entry, i) => renderLeaderCard(entry, catDef, i))}
                                 </div>
                             </div>

--- a/frontend/src/components/seasons/Seasons.tsx
+++ b/frontend/src/components/seasons/Seasons.tsx
@@ -24,7 +24,7 @@ import { countryCodeForTeam } from "../../functions/flags";
 import StandingsTab from "./Standings";
 
 import {
-    FaRankingStar, FaClipboardList, FaUserGroup, FaEarthAmericas, FaCalendarDays,
+    FaRankingStar, FaClipboardList, FaEarthAmericas, FaCalendarDays,
     FaChevronDown, FaBaseball, FaChevronRight, FaChevronLeft,
     FaStar, FaRegStar, FaArrowsRotate, FaTrophy
 } from "react-icons/fa6";
@@ -258,7 +258,7 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
         { id: "standings", label: "Standings", icon: <FaRankingStar /> },
         { id: "leaders", label: "Leaders", icon: <FaTrophy /> },
         { id: "teams", label: "Teams", icon: <FaClipboardList /> },
-        { id: "players", label: "Players", icon: <FaUserGroup /> },
+        // { id: "players", label: "Players", icon: <FaUserGroup /> },
     ];
 
     // ************************
@@ -937,20 +937,17 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                         </div>
 
                                         <Tabs.List
-                                            className="grid gap-1 rounded-lg bg-(--background-tertiary) p-1"
-                                            style={{ gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))` }}
+                                            className="flex gap-1 rounded-lg bg-(--background-tertiary) p-1 overflow-x-auto scrollbar-hide"
                                         >
                                             {tabs.map((tab) => (
                                                 <Tabs.Trigger
                                                     key={tab.id}
                                                     value={tab.id}
-                                                    className="flex items-center justify-center gap-1.5 px-2 py-2 text-xs rounded-md
-                                                               data-[state=active]:bg-(--background-quaternary)
-                                                               data-[state=active]:font-bold
-                                                               data-[state=active]:text-(--showdown-blue)
-                                                               data-[state=inactive]:text-tertiary"
+                                                    className="flex flex-1 min-w-fit items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md whitespace-nowrap transition-colors duration-150
+                                                               data-[state=active]:bg-(--showdown-blue) data-[state=active]:text-white data-[state=active]:font-semibold data-[state=active]:shadow-sm
+                                                               data-[state=inactive]:text-tertiary data-[state=inactive]:hover:text-secondary"
                                                 >
-                                                    <span className="text-(--text-secondary)">{tab.icon}</span>
+                                                    <span>{tab.icon}</span>
                                                     <span>{tab.label}</span>
                                                 </Tabs.Trigger>
                                             ))}
@@ -971,10 +968,10 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                     {/* Standings Tab */}
                             		<Tabs.Content
                                         value="standings"
-                                        className="focus:outline-none data-[state=inactive]:hidden lg:pt-6 lg:pr-6"
+                                        className="focus:outline-none data-[state=inactive]:hidden"
                                         forceMount
                                     >
-                                        <div className="space-y-2 pb-24">
+                                        <div className="space-y-2 pb-24 lg:pt-6 lg:pr-6">
                                             <StandingsTab
                                                 standingsEntries={standingsEntries}
                                                 selectedSportId={selectedSport?.id}
@@ -987,7 +984,7 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                     {/* Schedule Tab - Only for ongoing seasons */}
                                     <Tabs.Content
                                         value="schedule"
-                                        className="focus:outline-none data-[state=inactive]:hidden lg:pt-6 lg:pr-6"
+                                        className="focus:outline-none data-[state=inactive]:hidden"
                                         forceMount
                                     >
                                         {selectedGamePk !== null ? (
@@ -1000,7 +997,7 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                                 onBack={() => setSelectedGamePk(null)}
                                             />
                                         ) : (
-                                        <div className="space-y-5 lg:pr-6">
+                                        <div className="space-y-5 lg:pt-6 lg:pr-6">
                                                 <div className="rounded-xl border border-(--divider) bg-(--background-secondary) px-4 py-3">
                                                     <div className="flex items-center justify-between">
                                                         <button
@@ -1086,10 +1083,11 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                     {/* Teams Tab */}
                                     <Tabs.Content
                                         value="teams"
-                                        className="focus:outline-none data-[state=inactive]:hidden lg:pt-6 lg:pr-6"
-                                    >                                        
+                                        className="focus:outline-none data-[state=inactive]:hidden"
+                                    >
+                                        <div className="lg:pt-6 lg:pr-6">
                                             {selectedTeam && (
-                                                <TeamRoster 
+                                                <TeamRoster
                                                     team={selectedTeam}
                                                     sportId={selectedSport?.id || null}
                                                     roster={selectedRoster}
@@ -1099,21 +1097,23 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                                     onToggleStar={() => toggleStarTeam(selectedTeam)}
                                                 />
                                             )}
+                                        </div>
                                     </Tabs.Content>
 
                                     {/* Leaders Tab */}
                                     <Tabs.Content
                                         value="leaders"
-                                        className="focus:outline-none data-[state=inactive]:hidden lg:pt-6 lg:pr-6"
-                                        forceMount
+                                        className="focus:outline-none data-[state=inactive]:hidden"
                                     >
-                                        <SeasonLeaders
-                                            seasonId={selectedSeason.season_id}
-                                            season={selectedSeason.season_id ? parseInt(selectedSeason.season_id) : 2026}
-                                            showdownSet={userShowdownSet}
-                                            sportId={selectedSport?.id}
-                                            isActive={activeTab === 'leaders'}
-                                        />
+                                        <div className="lg:pt-6">
+                                            <SeasonLeaders
+                                                seasonId={selectedSeason.season_id}
+                                                season={selectedSeason.season_id ? parseInt(selectedSeason.season_id) : 2026}
+                                                showdownSet={userShowdownSet}
+                                                sportId={selectedSport?.id}
+                                                isActive={activeTab === 'leaders'}
+                                            />
+                                        </div>
                                     </Tabs.Content>
 
                                     {/* Players Tab */}

--- a/frontend/src/components/seasons/Seasons.tsx
+++ b/frontend/src/components/seasons/Seasons.tsx
@@ -994,6 +994,7 @@ export default function Seasons({ type, title, subtitle, staticSports, staticSea
                                                 season={selectedSeason?.season_id ? parseInt(selectedSeason.season_id) : undefined}
                                                 showdownSet={userShowdownSet}
                                                 isActive={activeTab === 'schedule'}
+                                                className="lg:py-6 lg:pr-6"
                                                 onBack={() => setSelectedGamePk(null)}
                                             />
                                         ) : (

--- a/mlb_showdown_bot/core/card/showdown_player_card.py
+++ b/mlb_showdown_bot/core/card/showdown_player_card.py
@@ -5152,7 +5152,7 @@ class ShowdownPlayerCard(BaseModel):
                     image = None
                     type_override = self.player_type_override.override_string if self.player_type_override else ''
                     stats_period = self.stats_period.type.player_image_search_term if self.stats_period.type.player_image_search_term else ''
-                    cached_image_filename = f"{img_component.source_name}-{self.year}-({self.bref_id})-({self.team.value}){type_override}{stats_period}.png"
+                    cached_image_filename = f"{img_component.source_name}-{self.year}-({self.bref_id or self.mlb_id})-({self.team.value}){type_override}{stats_period}.png"
                     cached_image_path = os.path.join(os.path.dirname(__file__), 'image_uploads', cached_image_filename)
                     if not self.ignore_cache:
                         try:

--- a/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
+++ b/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
@@ -150,10 +150,10 @@ class NormalizedPlayerStats(BaseModel):
         """Ensures pos_season is always a string, defaults to empty string if None"""
         return str(value) if value is not None else None
     
-    @field_validator('dWAR', 'bWAR', 'age', mode='before')
+    @field_validator('dWAR', 'bWAR', 'age', 'earned_run_avg', mode='before')
     def validate_empty_stats(cls, value) -> float:
         """Defaults dWAR, bWAR, and age to None if empty string"""
-        return None if value is not None and (str(value) == '' or str(value) == '--') else value
+        return None if value is not None and (str(value) == '' or str(value) == '--' or str(value) == '-.--') else value
 
     @field_validator('PA', 'AB', mode='before')
     def validate_counting_ints(cls, value) -> int:

--- a/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
+++ b/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
@@ -150,10 +150,10 @@ class NormalizedPlayerStats(BaseModel):
         """Ensures pos_season is always a string, defaults to empty string if None"""
         return str(value) if value is not None else None
     
-    @field_validator('dWAR', mode='before')
-    def validate_dwar(cls, value) -> float:
-        """Defaults dWAR to None if empty string"""
-        return None if value is not None and str(value) == '' else value
+    @field_validator('dWAR', 'bWAR', 'age', mode='before')
+    def validate_empty_stats(cls, value) -> float:
+        """Defaults dWAR, bWAR, and age to None if empty string"""
+        return None if value is not None and (str(value) == '' or str(value) == '--') else value
 
     @field_validator('PA', 'AB', mode='before')
     def validate_counting_ints(cls, value) -> int:
@@ -166,13 +166,13 @@ class NormalizedPlayerStats(BaseModel):
         
         return int(value)
     
-    @field_validator('SB', mode='before')
+    @field_validator('SB', 'RBI', mode='before')
     def validate_zeroed_out_stats(cls, value) -> int:
         """Sets stats that are zero to None to indicate missing data"""
         if value is None:
             return 0
         
-        if str(value) == '':
+        if str(value) == '' or str(value) == '--':
             return 0
         
         return int(value)


### PR DESCRIPTION
### (DEV) Patch/4.11 - Feedback Round II

This pull request introduces several UI improvements and bug fixes to the season and game detail components, as well as some backend validation enhancements for player stats and image caching. The main themes are: better support for variable data in player stats, improved tab layouts and responsiveness in the frontend, and more robust handling of image caching for player cards.

**Frontend improvements and UI changes:**

* The `GameDetail` component now accepts a `className` prop, allowing for more flexible styling and layout control when embedded in other components. (`frontend/src/components/games/GameDetail.tsx`) [[1]](diffhunk://#diff-bceb2f1665f470f41674362270046b59d492f9e0abef4a164328ccf371d08304R45-R49) [[2]](diffhunk://#diff-bceb2f1665f470f41674362270046b59d492f9e0abef4a164328ccf371d08304L248-R249)
* The `SeasonLeaders` component displays up to 6 leaders per category instead of 3, and adjusts placeholder and card layouts for better responsiveness and consistency, especially on large screens. (`frontend/src/components/seasons/SeasonLeaders.tsx`) [[1]](diffhunk://#diff-df49485b078b4a9fb0306209d66b1a7d00223e8366573b7c0566733318d44e1eL101-R102) [[2]](diffhunk://#diff-df49485b078b4a9fb0306209d66b1a7d00223e8366573b7c0566733318d44e1eL268-R271) [[3]](diffhunk://#diff-df49485b078b4a9fb0306209d66b1a7d00223e8366573b7c0566733318d44e1eL291-R291) [[4]](diffhunk://#diff-df49485b078b4a9fb0306209d66b1a7d00223e8366573b7c0566733318d44e1eL310-R310) [[5]](diffhunk://#diff-df49485b078b4a9fb0306209d66b1a7d00223e8366573b7c0566733318d44e1eL233-R233) [[6]](diffhunk://#diff-df49485b078b4a9fb0306209d66b1a7d00223e8366573b7c0566733318d44e1eL300-R300)
* The `Seasons` component's tab bar is now horizontally scrollable and more mobile-friendly, with improved tab styling and active/inactive states. Padding and spacing are consistently applied to tab content for better alignment across different tabs. The "Players" tab is commented out for now, removing it from the UI. (`frontend/src/components/seasons/Seasons.tsx`) [[1]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0L27-R27) [[2]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0L261-R261) [[3]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0L940-R950) [[4]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0L974-R974) [[5]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0L990-R987) [[6]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0R997-R1001) [[7]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0L1089-R1089) [[8]](diffhunk://#diff-33edfcbce0df1502b89c6a6b21c3bf7f9c7ec3159130eeacfeddc925ad9630c0R1101-R1117)

**Backend and data validation improvements:**

* The player stats model now more robustly handles empty or missing values for several fields (`dWAR`, `bWAR`, `age`, `earned_run_avg`, `SB`, `RBI`), defaulting to `None` or `0` as appropriate, and recognizing additional placeholder values like `'--'` and `'-.--'`. (`mlb_showdown_bot/core/card/stats/normalized_player_stats.py`) [[1]](diffhunk://#diff-188407ecb9f855507d456dbe7aa3cebecd5927c8d822f92d11108a308a3f2ac7L153-R156) [[2]](diffhunk://#diff-188407ecb9f855507d456dbe7aa3cebecd5927c8d822f92d11108a308a3f2ac7L169-R175)
* The player image caching logic now falls back to `mlb_id` if `bref_id` is missing, preventing errors and improving cache hit rates for player images. (`mlb_showdown_bot/core/card/showdown_player_card.py`)