### PR TITLE
Fix issue where MILB pitchers don't have split stats

### DIFF
--- a/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
+++ b/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
@@ -1108,6 +1108,9 @@ class PlayerStatsNormalizer:
             types=[StatTypeEnum.STAT_SPLITS],
             seasons=stats_period.year_list
         )
+
+        if not pitching_stat_splits or len(pitching_stat_splits) == 0:
+            return None
         
         total_ip_list = []
         total_gs = 0


### PR DESCRIPTION
### Fix issue where MILB pitchers don't have split stats

This pull request adds a defensive check to the `_extract_ip_per_gs` function to handle cases where `pitching_stat_splits` is empty, preventing potential errors when processing player pitching stats.

Error handling improvement:

* Added a check to return `None` early if `pitching_stat_splits` is empty in `_extract_ip_per_gs`, improving robustness when no pitching data is available.