### PR TITLE
Patch/4.11: Fix Icons

### DIFF
--- a/mlb_showdown_bot/core/card/showdown_player_card.py
+++ b/mlb_showdown_bot/core/card/showdown_player_card.py
@@ -1462,7 +1462,7 @@ class ShowdownPlayerCard(BaseModel):
             if stat_category:
                 is_top_2 = len([
                     a for a in self.accolades 
-                    if ("2ND" in a or "1ST" in a or "LEADER" in a) 
+                    if (a.startswith("2ND") or a.startswith("1ST") or "LEADER" in a) 
                         and (( f" {icon.accolade_search_term}" in a or a.startswith(f"{icon.accolade_search_term} ") ) and 'SO/9' not in a)
                 ]) > 0
                 is_leader = self.stats_for_card.get(f"is_{stat_category.lower()}_leader", False)

--- a/mlb_showdown_bot/core/card/showdown_player_card.py
+++ b/mlb_showdown_bot/core/card/showdown_player_card.py
@@ -1460,7 +1460,11 @@ class ShowdownPlayerCard(BaseModel):
             
             # LEADER
             if stat_category:
-                is_top_2 = len([a for a in self.accolades if ("2ND" in a or "1ST" in a or "LEADER" in a) and (f" {icon.accolade_search_term}" in a and 'SO/9' not in a)]) > 0
+                is_top_2 = len([
+                    a for a in self.accolades 
+                    if ("2ND" in a or "1ST" in a or "LEADER" in a) 
+                        and (( f" {icon.accolade_search_term}" in a or a.startswith(f"{icon.accolade_search_term} ") ) and 'SO/9' not in a)
+                ]) > 0
                 is_leader = self.stats_for_card.get(f"is_{stat_category.lower()}_leader", False)
                 if is_top_2 or is_leader:
                     icons.append(icon)


### PR DESCRIPTION
### Patch/4.11: Fix Icons

Fix issues where:

- Leaders not being picked up for icons
- Ranks that included "1st" or "2nd" substrings were being counted
  - ex: "22nd", "21st"