### PR TITLE
4.2 Patch: Fix missing league info for teams with different IDs across MLB and BREF

### DIFF
--- a/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
+++ b/mlb_showdown_bot/core/card/stats/normalized_player_stats.py
@@ -905,7 +905,10 @@ class PlayerStatsNormalizer:
         )
         for split in standard_stat_splits or []:
             team = split.team
-            if team and team.abbreviation == primary_team_id:
+            if not team or not team.abbreviation:
+                continue
+            team_bref_id = PlayerStatsNormalizer._convert_to_bref_team_id(team.abbreviation)
+            if team_bref_id == primary_team_id:
                 if team.league and team.league.abbreviation:
                     return team.league.abbreviation
                 


### PR DESCRIPTION
Fixes LG_ID null issue for teams that have different abbreviations between BREF and MLB.com 