### PR TITLE
Fix 2-way players in Explore snapshotting

### DIFF
--- a/mlb_showdown_bot/core/card/card_generation.py
+++ b/mlb_showdown_bot/core/card/card_generation.py
@@ -677,11 +677,7 @@ def generate_random_player(**kwargs) -> PlayerArchive:
     if random_player:
         return random_player
 
-# Players that should generate two separate cards (one Hitter, one Pitcher).
-# TODO: replace hard-coded IDs with a general two-way player detection strategy.
-_TWO_WAY_PLAYER_IDS: set[int] = {660271}  # Ohtani
-
-def generate_cards(player_ids: list[str], years: list[int], keep_as_py_objects:bool=False, sets: list[str] = None, inject_bref_ids: bool = False, points_change_cutoff_date: date = None, **kwargs) -> list[dict[str, Any]]:
+def generate_cards(player_ids: list[str], years: list[int], keep_as_py_objects:bool=False, sets: list[str] = None, inject_bref_ids: bool = False, points_change_cutoff_date: date = None, two_way_ids: list[str] = None, **kwargs) -> list[dict[str, Any]]:
     """Generate multiple cards for a list of player ids and a year. Only works with MLB API datasource.
 
     Args:
@@ -754,9 +750,10 @@ def generate_cards(player_ids: list[str], years: list[int], keep_as_py_objects:b
     errors: list[tuple[str, str]] = []
     for player_data in player_stats.players:
         # Two-way players (e.g. Ohtani) get one card per type; all others get a single card.
+        is_two_way = two_way_ids and player_data.id in two_way_ids
         player_type_overrides: list[PlayerType | None] = (
             [PlayerType.HITTER, PlayerType.PITCHER]
-            if player_data.id in _TWO_WAY_PLAYER_IDS
+            if is_two_way
             else [None]
         )
         skip_player = False
@@ -811,6 +808,12 @@ def generate_cards(player_ids: list[str], years: list[int], keep_as_py_objects:b
                         image=ShowdownImage(**card_kwargs),
                         **card_kwargs
                     )
+
+                    # Remove player type override for the hitter side if this is a two-way player
+                    # This will allow proper joining to the player_season_stats table via ID
+                    if is_two_way and card.player_type == PlayerType.HITTER:
+                        card.player_type_override = None
+
                     final_data: dict[str, Any] = {
                         "card": card if keep_as_py_objects else card.as_json(),
                     }

--- a/mlb_showdown_bot/scripts/season/rosters.py
+++ b/mlb_showdown_bot/scripts/season/rosters.py
@@ -54,7 +54,8 @@ def snapshot_rosters(
         print("Generating cards for rostered players...")
         player_ids = [roster['player_id'] for roster in rosters]
         player_id_chunks = [player_ids[i:i + 10] for i in range(0, len(player_ids), 10)]
-        
+        two_way_ids = [roster['player_id'] for roster in rosters if roster.get('position', 'N/A') == 'TWP']
+
         for idx, chunk in enumerate(player_id_chunks): 
             print(f"Processing chunk {idx + 1}/{len(player_id_chunks)} with player IDs: {chunk}")
             # In a real implementation, you would call the card generation function here
@@ -70,6 +71,7 @@ def snapshot_rosters(
                 keep_as_py_objects=True,
                 inject_bref_ids=True,
                 points_change_cutoff_date=date.today() - timedelta(days=7),
+                two_way_ids=two_way_ids,
                 **card_settings
             )
             sleep(2)  # Add a delay between chunks to avoid overwhelming the API


### PR DESCRIPTION
### Fix 2-way players in Explore snapshotting

This pull request improves the handling of two-way players (such as Shohei Ohtani) in the card generation process. The main change is to make the detection and processing of two-way players more flexible by removing the hard-coded player ID and instead passing a list of two-way player IDs dynamically. There are also adjustments to ensure proper joining and data integrity for two-way player cards.

**Two-way player handling improvements:**

* Removed the hard-coded `_TWO_WAY_PLAYER_IDS` set and updated `generate_cards` to accept a `two_way_ids` argument, allowing dynamic specification of two-way players.
* Updated the logic in `generate_cards` to check if a player is a two-way player using the new `two_way_ids` argument, and generate both hitter and pitcher cards accordingly.
* Ensured that, for two-way players, the `player_type_override` is removed for the hitter side to allow proper database joins.

**Roster script updates:**

* Modified `snapshot_rosters` to build the `two_way_ids` list from roster data (where position is 'TWP') and pass it to `generate_cards`, enabling dynamic two-way player detection during roster processing. [[1]](diffhunk://#diff-0225d98bc7a1085f04ec5dc14e967a1c86f8a28713763909757bf994ee5d9237R57) [[2]](diffhunk://#diff-0225d98bc7a1085f04ec5dc14e967a1c86f8a28713763909757bf994ee5d9237R74)