### PR TITLE
4.3 Patch: Fix Cutoff Fangraphs Defense

### DIFF
--- a/mlb_showdown_bot/core/fangraphs/client.py
+++ b/mlb_showdown_bot/core/fangraphs/client.py
@@ -81,7 +81,7 @@ class FangraphsAPIClient:
                 "season": str(season_end),   # END YEAR
                 "ind": "0",
                 "team": "0",
-                "pageitems": "2000",
+                "pageitems": "4000",
                 "pagenum": "1",
             }
 


### PR DESCRIPTION
### 4.3 Patch: Fix Cutoff Fangraphs Defense

Fixes an issue where fan graphs defense was sorting only the first 2000 occurrences. 2026 season there are now over 2k results